### PR TITLE
Chore: Support node 6 plus only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ before_install:
   - "npm install npm -g"
 node_js:
   - "stable"
-  - "4"
-  - "5"
   - "6"
+  - "8"
+  - "10"
 env:
   - TEST_SUITE=test
 script: "npm run-script $TEST_SUITE"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test:watch": "jest --watch --verbose=false",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "jest": {
     "automock": false,
     "bail": true


### PR DESCRIPTION
Closes #31 

- Changes node versions tested in `.travis.yml` (remove 4 and 5, add 8 and 10)
- Addes `engines` of node >= 6 to package.json (in line with other dependencies)

This should fix the build, tests pass locally.